### PR TITLE
Revert "[***NO_CI***] Don't use console mode on macOS PyInstaller"

### DIFF
--- a/umatracker-mac.spec
+++ b/umatracker-mac.spec
@@ -67,18 +67,20 @@ for lib_path in lib_path_list:
                         )
 a.binaries += tmp
 
-pyz = PYZ(a.pure, a.zipped_data, cipher=None)
+pyz = PYZ(a.pure, cipher=None)
 exe = EXE(pyz,
         a.scripts,
+        a.binaries,
+        a.zipfiles,
+        a.datas,
+        a.binaries,
         name='UMATracker-Tracking',
         debug=DEBUG_FLAG,
         strip=None,
         upx=True,
-        exclude_binaries=True,
         console=DEBUG_FLAG, icon='./icon/icon.icns')
 
 coll = COLLECT(exe,
-        a.scripts,
         a.binaries,
         a.zipfiles,
         a.datas,

--- a/umatracker-mac.spec
+++ b/umatracker-mac.spec
@@ -75,7 +75,7 @@ exe = EXE(pyz,
         strip=None,
         upx=True,
         exclude_binaries=True,
-        console=False, icon='./icon/icon.icns')
+        console=DEBUG_FLAG, icon='./icon/icon.icns')
 
 coll = COLLECT(exe,
         a.scripts,


### PR DESCRIPTION
This reverts commit 2da3ac1576efc0384d8c2cfd00687c6747fc81ed.